### PR TITLE
Fix docs example link and add Doc parser page

### DIFF
--- a/docs/sdk/07-services.md
+++ b/docs/sdk/07-services.md
@@ -1,6 +1,6 @@
 # Services
 
-The SDK exposes helpers for common resources such as language models, storage backends and vector databases. You can access them through an agent instance or directly from the SDK. See [`10-llm-storage-vectors.ts`](../../examples/01-agent-code-skill/10-llm-storage-vectors.ts) and [`pinecone.ts`](../../examples/04-VectorDB/pinecone.ts) for working code.
+The SDK exposes helpers for common resources such as language models, storage backends and vector databases. You can access them through an agent instance or directly from the SDK. See [`10-llm-storage-vectors.ts`](../../examples/01-agent-code-skill/10-llm-storage-vectors.ts) and [`upsert-and-search.ts`](../../examples/05-VectorDB-with-agent/upsert-and-search.ts) for working code.
 
 ## LLMs
 

--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -1,19 +1,19 @@
 # API Reference
 
-This section describes the main classes and utilities exposed by the SmythOS SDK.
-Each page focuses on a single object with examples adapted from the `examples` folder.
+This section describes the main classes and utilities exposed by the SmythOS SDK. Each page focuses on a single object with examples adapted from the `examples` folder.
 
 ## Objects
 
-- [Agent](agent.md)
-- [Chat](chat.md)
-- [LLM](llm.md)
-- [LLMInstance](llm-instance.md)
-- [Model](model.md)
-- [Storage](storage.md)
-- [VectorDB](vectordb.md)
-- [Team](team.md)
-- [Component](component.md)
+- [Agent](agent.md) – build agents with skills and built‑in services
+- [Chat](chat.md) – manage conversational state
+- [LLM](llm.md) – create language model instances
+- [LLMInstance](llm-instance.md) – call a single model via prompt or stream
+- [Model](model.md) – configuration objects for importing `.smyth` workflows
+- [Storage](storage.md) – connectors for reading and writing files
+- [VectorDB](vectordb.md) – connectors for vector databases
+- [Doc](doc.md) – parse files into structured documents
+- [Team](team.md) – group agents sharing storage and vectors
+- [Component](component.md) – building blocks of workflows
 
 ## Types
 

--- a/docs/sdk/api/doc.md
+++ b/docs/sdk/api/doc.md
@@ -1,0 +1,12 @@
+# Doc and DocParser
+
+`Doc` is a collection of helper functions for parsing files into structured documents. The returned instance exposes a `.parse()` method which extracts text, metadata and optional images from the source.
+
+```typescript
+import { Doc } from '@smythos/sdk';
+
+const parsed = await Doc.pdf('file.pdf').parse();
+console.log(parsed.title);
+```
+
+Supported factories include `pdf`, `docx`, `md` and `text`. See [`doc-parser.ts`](../../examples/04-VectorDB-no-agent/doc-parser.ts) for a working script.


### PR DESCRIPTION
## Summary
- fix incorrect link to vector DB example
- document the Doc parser helpers
- expand the API index with short descriptions for each object

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68500407710c83258d2bc7367d65dddc