### PR TITLE
[ImageGenerator] throw error when api key missing for Runware

### DIFF
--- a/packages/core/src/Components/ImageGenerator.class.ts
+++ b/packages/core/src/Components/ImageGenerator.class.ts
@@ -262,6 +262,10 @@ const imageGenerator = {
         const teamId = agent.teamId;
         const apiKey = (await getCredentials(AccessCandidate.team(teamId), 'runware')) as string;
 
+        if (!apiKey) {
+            throw new Error('Runware API key is missing. Please provide a valid key to continue.');
+        }
+
         const runware = new Runware({ apiKey });
         await runware.ensureConnection();
 


### PR DESCRIPTION
## 📝 Description

provide early feedback if the API key for Runware is missing in the ImageGenerator component.

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [x] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [x] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)
