### PR TITLE
unified code_imports and code_body into single code key for lambda code connector

### DIFF
--- a/packages/sdk/src/Components/generated/ServerlessCode.ts
+++ b/packages/sdk/src/Components/generated/ServerlessCode.ts
@@ -11,6 +11,8 @@ export interface TServerlessCodeSettings {
     code_imports?: string;
     /** Code */
     code_body?: string;
+    /** Code */
+    code?: string;
     /** Deploy */
     deploy_btn?: string;
     /** AWS Access Key ID */


### PR DESCRIPTION

## 📝 Description

Unified code_imports and code_body into single code key for lambda code connector. Also, integrated it with ServerlessCode Component. Now users don't need to provide code_body and code_imports separately. Only "code" key is required, which can contain both imports and body. 
Code must include async main function on the root level.

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [x] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [✅] Self-review performed
-   [✅] Tests added/updated
-   [✅] Documentation updated (if needed)
