### PR TITLE
filter RAG search result based on score

### DIFF
--- a/packages/core/src/Components/DataSourceLookup.class.ts
+++ b/packages/core/src/Components/DataSourceLookup.class.ts
@@ -29,8 +29,8 @@ export class DataSourceLookup extends Component {
             // Need to reserve 30 characters for the prefixed unique id
             'string.max': `The length of the 'namespace' name must be 50 characters or fewer.`,
         }),
-        scoreThreshold: Joi.number().optional().allow('').label('Score Threshold'),
-        includeScore: Joi.boolean().optional().allow('').label('Score Threshold'),
+        scoreThreshold: Joi.number().optional().label('Score Threshold'),
+        includeScore: Joi.boolean().optional().label('Score Threshold'),
     });
     constructor() {
         super();

--- a/packages/core/src/Components/DataSourceLookup.class.ts
+++ b/packages/core/src/Components/DataSourceLookup.class.ts
@@ -30,7 +30,7 @@ export class DataSourceLookup extends Component {
             'string.max': `The length of the 'namespace' name must be 50 characters or fewer.`,
         }),
         scoreThreshold: Joi.number().optional().label('Score Threshold'),
-        includeScore: Joi.boolean().optional().label('Score Threshold'),
+        includeScore: Joi.boolean().optional().label('Include Score'),
     });
     constructor() {
         super();


### PR DESCRIPTION
## 📝 Description

filter search result from RAG Search component based on score threshold set by user
return score value when Include score is enabled

## 🔗 Related Issues

[<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->](https://app.clickup.com/t/86eu5nk0m)

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [x] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering search results by a configurable score threshold.
  * Option to include the score of each result in the output.
* **Enhancements**
  * Results can now include both metadata and score information based on configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->