### PR TITLE
added 500 ms delay after lambda created for  aws lambda trust policy propagation

### DIFF
--- a/packages/core/src/helpers/AWSLambdaCode.helper.ts
+++ b/packages/core/src/helpers/AWSLambdaCode.helper.ts
@@ -203,9 +203,12 @@ export async function createOrUpdateLambdaFunction(functionName, zipFilePath, aw
             };
 
             const functionCreateCommand = new CreateFunctionCommand(functionParams);
-            const functionResponse = await client.send(functionCreateCommand);
+            await client.send(functionCreateCommand);
             // console.log('Function ARN:', functionResponse.FunctionArn);
             await verifyFunctionDeploymentStatus(functionName, client);
+            // wait 500 ms to let the function trust policy be applied
+            // it will only occur when the function is created for the first time
+            await new Promise((resolve) => setTimeout(resolve, 500));
         }
     } catch (error) {
         throw error;


### PR DESCRIPTION

## 📝 Description

NodeJs component fails on first time execution because of Lambda trust policy propagation delay.
So, Now 500 ms delay is added after lambda created so it will propagate before first execution.
It will take 500 ms extra only on the first execution (when lambda is actually created)

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [x] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [✅] Self-review performed
-   [✅] Tests added/updated
-   [✅] Documentation updated (if needed)
