### PR TITLE
Add support for new and old  OAuth id for configuration in API calls

### DIFF
--- a/packages/core/src/Components/APICall/APICall.class.ts
+++ b/packages/core/src/Components/APICall/APICall.class.ts
@@ -114,7 +114,8 @@ export class APICall extends Component {
             let Headers: any = {};
             let _error: any = undefined;
             try {
-                if (config?.data?.oauth_con_id !== '' && config?.data?.oauth_con_id !== 'None') {
+                // To support both old and new OAuth configuration, we check for both oauth_con_id and oauthService.
+                if ((config?.data?.oauth_con_id !== '' && config?.data?.oauth_con_id !== 'None') || (config?.data?.oauthService !== '' && config.data.oauthService !== 'None')) {
                     const additionalParams = extractAdditionalParamsForOAuth1(reqConfig);
                     const oauthHeaders = await generateOAuthHeaders(agent, config, reqConfig, logger, additionalParams);
                     //reqConfig.headers = { ...reqConfig.headers, ...oauthHeaders };

--- a/packages/core/src/Components/APICall/OAuth.helper.ts
+++ b/packages/core/src/Components/APICall/OAuth.helper.ts
@@ -176,7 +176,8 @@ export const buildOAuth1Header = (url, method, oauth1Credentials, additionalPara
 export const retrieveOAuthTokens = async (agent, config) => {
     let tokenKey: any = null;
     try {
-        tokenKey = config?.data?.oauth_con_id;
+        // To support both old and new OAuth configuration, we check for both oauth_con_id and config.id (component id)
+        tokenKey = config?.data?.oauth_con_id || `OAUTH_${config?.id}_TOKENS`;
 
         try {
             const result: any = await managedVault.user(AccessCandidate.agent(agent.id)).get(tokenKey);
@@ -423,7 +424,7 @@ async function getClientCredentialToken(tokensData, logger, keyId, oauthTokens, 
                 if (!updatedData.team) updatedData.team = agent.teamId;
                 if (!updatedData.oauth_info) {
                     updatedData.oauth_info = {
-                        oauth_keys_prefix: `OAUTH_${config?.data?.oauth_con_id?.split('_')[1]}`,
+                        oauth_keys_prefix: `OAUTH_${config?.data?.oauth_con_id?.split('_')[1] || config?.id}`,
                         service: 'oauth2_client_credentials',
                         tokenURL,
                         clientID,


### PR DESCRIPTION
## 📝 Description

Updated APICall and OAuth helper logic to handle both legacy 'oauth_con_id' and new 'oauthService' or component ID for OAuth configuration. This improves compatibility with different OAuth setups and ensures correct token retrieval and header generation.

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [X ] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [ ] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)
