### PR TITLE
Feat: add timestamp format support to FTimestamp component

### DIFF
--- a/packages/core/src/Components/FTimestamp.class.ts
+++ b/packages/core/src/Components/FTimestamp.class.ts
@@ -1,7 +1,21 @@
 import { Component } from './Component.class';
 import { IAgent as Agent } from '@sre/types/Agent.types';
+import Joi from 'joi';
+import dayjs from 'dayjs';
 
 export class FTimestamp extends Component {
+    protected configSchema = Joi.object({
+        format: Joi.string()
+            .valid('unix', 'iso', 'timestamp')
+            .pattern(/^[YMDHhmsSSZzAa\s\-\/:,\.]*$/, 'custom dayjs format')
+            .default('unix')
+            .label('Timestamp Format')
+            .messages({
+                'string.pattern.name': 'Custom format contains invalid characters. Use dayjs format tokens like YYYY-MM-DD HH:mm:ss',
+                'any.only': 'Format must be "unix", "iso", "timestamp", or a valid dayjs format pattern'
+            })
+    });
+
     constructor() {
         super();
     }
@@ -11,15 +25,40 @@ export class FTimestamp extends Component {
         const logger = this.createComponentLogger(agent, config);
         try {
             const _error = undefined;
-            const format = config.data.format; //TODO set timestamp format
-            const Timestamp = Date.now();
-            logger.debug(`Timestamp : ${Timestamp}`);
+            const format = config.data.format || 'unix';
+            const now = dayjs();
+            
+            let Timestamp: number | string;
+            
+            switch (format) {
+                case 'unix':
+                case 'timestamp':
+                    Timestamp = Date.now();
+                    logger.debug(`Unix timestamp: ${Timestamp}`);
+                    break;
+                case 'iso':
+                    Timestamp = now.toISOString();
+                    logger.debug(`ISO timestamp: ${Timestamp}`);
+                    break;
+                default:
+                    // Custom dayjs format
+                    try {
+                        Timestamp = now.format(format);
+                        logger.debug(`Custom formatted timestamp (${format}): ${Timestamp}`);
+                    } catch (formatError) {
+                        logger.error(`Invalid format string: ${format}`);
+                        // Fallback to unix timestamp for invalid formats
+                        Timestamp = Date.now();
+                        logger.debug(`Fallback unix timestamp: ${Timestamp}`);
+                    }
+                    break;
+            }
 
             return { Timestamp, _error, _debug: logger.output, _debug_time: logger.elapsedTime };
         } catch (err: any) {
             const _error = err?.response?.data || err?.message || err.toString();
-            logger.error(` Error processing data \n${_error}\n`);
-            return { hash: undefined, _error, _debug: logger.output, _debug_time: logger.elapsedTime };
+            logger.error(` Error processing timestamp \n${_error}\n`);
+            return { Timestamp: undefined, _error, _debug: logger.output, _debug_time: logger.elapsedTime };
         }
     }
 }

--- a/packages/core/tests/unit/components/FTimestamp.test.ts
+++ b/packages/core/tests/unit/components/FTimestamp.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FTimestamp } from '../../../src/Components/FTimestamp.class';
+import { IAgent } from '../../../src/types/Agent.types';
+import { setupSRE } from '../../utils/sre';
+
+setupSRE();
+
+const mockAgent: IAgent = {
+    id: 'test-agent-id',
+    agentRuntime: { debug: false },
+    sse: null,
+    isKilled: vi.fn(() => false),
+} as any;
+
+describe('FTimestamp Component', () => {
+    let component: FTimestamp;
+    let originalDateNow: () => number;
+    const mockTimestamp = 1642780800000; // January 21, 2022 12:00:00 UTC
+
+    beforeEach(() => {
+        component = new FTimestamp();
+        originalDateNow = Date.now;
+        Date.now = vi.fn(() => mockTimestamp);
+    });
+
+    afterEach(() => {
+        Date.now = originalDateNow;
+    });
+
+    it('should return unix timestamp by default', async () => {
+        const result = await component.process({}, { data: {}, name: 'test' }, mockAgent);
+
+        expect(result.Timestamp).toBe(mockTimestamp);
+        expect(result._error).toBeUndefined();
+        expect(typeof result.Timestamp).toBe('number');
+    });
+
+    it('should return unix timestamp when format is "unix"', async () => {
+        const config = { data: { format: 'unix' }, name: 'test' };
+        const result = await component.process({}, config, mockAgent);
+
+        expect(result.Timestamp).toBe(mockTimestamp);
+        expect(typeof result.Timestamp).toBe('number');
+    });
+
+    it('should return ISO string when format is "iso"', async () => {
+        const config = { data: { format: 'iso' }, name: 'test' };
+        const result = await component.process({}, config, mockAgent);
+
+        expect(typeof result.Timestamp).toBe('string');
+        expect(result.Timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+
+    it('should format using custom dayjs patterns', async () => {
+        const config = { data: { format: 'YYYY-MM-DD' }, name: 'test' };
+        const result = await component.process({}, config, mockAgent);
+
+        expect(typeof result.Timestamp).toBe('string');
+        expect(result.Timestamp).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('should include standard component output properties', async () => {
+        const result = await component.process({}, { data: {}, name: 'test' }, mockAgent);
+
+        expect(result).toHaveProperty('Timestamp');
+        expect(result).toHaveProperty('_error');
+        expect(result).toHaveProperty('_debug');
+        expect(result).toHaveProperty('_debug_time');
+    });
+
+    it('should handle errors gracefully', async () => {
+        const invalidConfig = { data: { format: null }, name: 'test' };
+        const result = await component.process({}, invalidConfig, mockAgent);
+
+        // Should fallback to default behavior
+        expect(result.Timestamp).toBeDefined();
+        expect(result._error).toBeUndefined();
+    });
+});
+


### PR DESCRIPTION
## 📝 Description

Implement timestamp format configuration for the FTimestamp component, resolving the TODO comment. Adds support for multiple timestamp formats including unix, ISO, and custom dayjs patterns while maintaining full backward compatibility.

**Key Features:**
- Support for 'unix', 'iso', 'timestamp', and custom dayjs format patterns
- Joi schema validation for format parameter with helpful error messages
- Graceful error handling with fallback to unix timestamp
- Comprehensive test suite covering all scenarios
- Zero breaking changes - existing usage continues to work unchanged

## 🔗 Related Issues

-   Fixes # _(if there's an issue number for the TODO)_
-   Relates to # _(if there are related enhancement requests)_

## 🔧 Type of Change

-   [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

-   [x] Self-review performed
-   [x] Tests added/updated
-   [ ] Documentation updated (if needed)