### PR TITLE
Fix: add null check for vault file in JSONFileVault watcher initialization

### DIFF
--- a/packages/core/src/subsystems/Security/Vault.service/connectors/JSONFileVault.class.ts
+++ b/packages/core/src/subsystems/Security/Vault.service/connectors/JSONFileVault.class.ts
@@ -201,6 +201,10 @@ export class JSONFileVault extends VaultConnector {
     }
 
     private initFileWatcher() {
+        if (!this.vaultFile) {
+            console.warn('Vault file not found, file watcher not initialized');
+            return;
+        }
         this.watcher = chokidar.watch(this.vaultFile, {
             persistent: false, // Don't keep the process running
             ignoreInitial: true,


### PR DESCRIPTION
## 📝 Description

Adds a safety check to prevent JSONFileVault file watcher initialization when the vault file is not there. This prevents potential runtime errors and adds appropriate warning logging for debugging purposes.

## 🔗 Related Issues

-   Fixes #
-   Relates to #

## 🔧 Type of Change

-   [x] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

-   [x] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)
