### PR TITLE
Fix OAuth config check for undefined values

### DIFF
--- a/packages/core/src/Components/APICall/APICall.class.ts
+++ b/packages/core/src/Components/APICall/APICall.class.ts
@@ -115,7 +115,7 @@ export class APICall extends Component {
             let _error: any = undefined;
             try {
                 // To support both old and new OAuth configuration, we check for both oauth_con_id and oauthService.
-                if ((config?.data?.oauth_con_id !== '' && config?.data?.oauth_con_id !== 'None') || (config?.data?.oauthService !== '' && config.data.oauthService !== 'None')) {
+                if ((config?.data?.oauth_con_id !== undefined && config?.data?.oauth_con_id !== '' && config?.data?.oauth_con_id !== 'None') || (config?.data?.oauthService !== '' && config.data.oauthService !== 'None')) {
                     const additionalParams = extractAdditionalParamsForOAuth1(reqConfig);
                     const oauthHeaders = await generateOAuthHeaders(agent, config, reqConfig, logger, additionalParams);
                     //reqConfig.headers = { ...reqConfig.headers, ...oauthHeaders };


### PR DESCRIPTION

## 📝 Description

Updated the OAuth configuration check to ensure 'oauth_con_id' is not undefined before proceeding. This prevents potential issues when 'oauth_con_id' is missing from the config data and makes the first check true if it is undefined

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes #
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [x] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [ ] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)
