### PR TITLE
docs: add pnpm tip and debug log note to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Install the [CLI](packages/cli/) globally and create a new project:
 npm i -g @smythos/cli
 sre create
 ```
+> **Tip**: SmythOS recommends using `pnpm` as the package manager.  
+> For troubleshooting, set `LOG_LEVEL="debug"` before running commands to see detailed logs.
 
 The CLI will guide you step-by-step to create your SDK project with the right configuration for your needs.
 


### PR DESCRIPTION
## 📝 Description

Added documentation improvements in the Quick Start section:
- Noted that SmythOS recommends using `pnpm` as the package manager.
- Added a tip about setting `LOG_LEVEL="debug"` for troubleshooting.
-
## 🔗 Related Issues

N/A


## 🔧 Type of Change


-   [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [x] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

-   [x] Self-review performed
-   [x] Tests added/updated
-   [x] Documentation updated (if needed)
