### PR TITLE
docs: fix quote mismatch in README chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Want chat mode ? easy
     let result = await chat.prompt("Hello, I'm Smyth")
     console.log(result);
 
-    result = await chat.prompt('Do you remember my name ?");
+    result = await chat.prompt('Do you remember my name ?');
     console.log(result);
 
 


### PR DESCRIPTION
## 📝 Description

Fixed a minor quote mismatch in the README chat example which caused a syntax error when copying the snippet. This improves the developer experience for anyone trying the SDK.

## 🔗 Related Issues

No linked issues for this small documentation fix.


## 🔧 Type of Change

-   [ ] 📚 Documentation update  (only example/README changed)


## ✅ Checklist

-   [ ] Self-review performed
-   [ ] Tests added/updated (not needed)
-   [ ] Documentation updated (README example fixed)