### PR TITLE
feat(llm): add OpenRouter as a native LLM provider

### DIFF
--- a/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenRouter.class.ts
+++ b/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenRouter.class.ts
@@ -1,0 +1,395 @@
+import OpenAI from 'openai';
+import EventEmitter from 'events';
+
+import { JSON_RESPONSE_INSTRUCTION, BUILT_IN_MODEL_PREFIX } from '@sre/constants';
+import {
+    TLLMMessageBlock,
+    ToolData,
+    TLLMMessageRole,
+    APIKeySource,
+    TLLMEvent,
+    BasicCredentials,
+    ILLMRequestFuncParams,
+    TLLMChatResponse,
+    ILLMRequestContext,
+    TLLMPreparedParams,
+    TLLMToolResultMessageBlock,
+    TLLMFinishReason,
+} from '@sre/types/LLM.types';
+import { LLMHelper } from '@sre/LLMManager/LLM.helper';
+import { LLMConnector } from '../LLMConnector';
+import { SystemEvents } from '@sre/Core/SystemEvents';
+import { Logger } from '@sre/helpers/Log.helper';
+import { hookAsync } from '@sre/Core/HookService';
+
+const logger = Logger('OpenRouterConnector');
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+type OpenRouterRequestBody = {
+    model: string;
+    messages: any[];
+    max_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    stop?: string[];
+    stream?: boolean;
+    tools?: any[];
+    tool_choice?: string;
+};
+
+/**
+ * OpenRouter LLM Connector
+ *
+ * OpenRouter is a unified gateway that provides access to 100+ models
+ * (Mistral, Llama, Qwen, Gemma, DeepSeek, Command R+, and more) through
+ * a single OpenAI-compatible API endpoint and a single API key.
+ *
+ * Why a dedicated connector instead of reusing OpenAIConnector:
+ * - OpenRouter requires identifying headers (HTTP-Referer, X-Title) that
+ *   the existing OpenAI connector has no mechanism to send.
+ * - A dedicated connector surfaces clear, provider-specific error messages
+ *   and log context, making debugging easier.
+ * - It provides a foundation for future OpenRouter-specific features such as
+ *   provider routing config, model fallback strategies, and cost tracking
+ *   via the usage.cost field returned by OpenRouter responses.
+ *
+ * API compatibility: OpenRouter follows the OpenAI chat completions format,
+ * so the request/response shape is identical. Streaming uses SSE exactly
+ * like OpenAI, and tool calling is fully supported on models that expose it.
+ */
+export class OpenRouterConnector extends LLMConnector {
+    public name = 'LLM:OpenRouter';
+
+    // ── Client Factory ────────────────────────────────────────────────────────
+    // A new client instance is created per-request so credentials are always
+    // fresh from the vault and never cached stale across key rotations.
+    private getClient(context: ILLMRequestContext): OpenAI {
+        const apiKey = (context.credentials as BasicCredentials)?.apiKey;
+
+        if (!apiKey) throw new Error('Please provide an API key for OpenRouter');
+
+        return new OpenAI({
+            apiKey,
+            baseURL: OPENROUTER_BASE_URL,
+            // OpenRouter requires these headers to identify the calling application.
+            // HTTP-Referer is used for rate-limit attribution; X-Title appears in
+            // the OpenRouter dashboard under "Your Apps".
+            defaultHeaders: {
+                'HTTP-Referer': 'https://smythos.com',
+                'X-Title': 'SmythOS',
+            },
+        });
+    }
+
+    // ── Non-streaming request ─────────────────────────────────────────────────
+    @hookAsync('LLMConnector.request')
+    protected async request({ acRequest, body, context, abortSignal }: ILLMRequestFuncParams): Promise<TLLMChatResponse> {
+        try {
+            logger.debug(`request ${this.name}`, acRequest.candidate);
+
+            const client = this.getClient(context);
+            const result = await client.chat.completions.create(body, { signal: abortSignal }) as any;
+
+            const message = result?.choices?.[0]?.message;
+            const finishReason = LLMHelper.normalizeFinishReason(result?.choices?.[0]?.finish_reason);
+            const toolCalls = message?.tool_calls;
+            const usage = result.usage;
+
+            this.reportUsage(usage, {
+                modelEntryName: context.modelEntryName,
+                keySource: context.isUserKey ? APIKeySource.User : APIKeySource.Smyth,
+                agentId: context.agentId,
+                teamId: context.teamId,
+            });
+
+            let toolsData: ToolData[] = [];
+            let useTool = false;
+
+            if (toolCalls) {
+                toolsData = toolCalls.map((tool, index) => ({
+                    index,
+                    id: tool.id,
+                    type: tool.type,
+                    name: tool.function.name,
+                    arguments: tool.function.arguments,
+                    role: TLLMMessageRole.Assistant,
+                }));
+                useTool = true;
+            }
+
+            return {
+                content: message?.content ?? '',
+                finishReason,
+                useTool,
+                toolsData,
+                message,
+                usage,
+            };
+        } catch (error) {
+            logger.error(`request ${this.name}`, error, acRequest.candidate);
+            throw error;
+        }
+    }
+
+    // ── Streaming request ─────────────────────────────────────────────────────
+    /**
+     * Stream request implementation.
+     *
+     * Error Handling Pattern:
+     * - Always returns an emitter, never throws — ensures consistent handling upstream.
+     * - Uses setImmediate to defer event emission to the next event loop tick.
+     *   This prevents the race condition where events fire before the caller has
+     *   had a chance to attach listeners (since streamRequest is async, the caller
+     *   must await the emitter before attaching — setImmediate bridges that gap).
+     * - Always emits TLLMEvent.End after any terminal event (Error, Abort).
+     */
+    @hookAsync('LLMConnector.streamRequest')
+    protected async streamRequest({ acRequest, body, context, abortSignal }: ILLMRequestFuncParams): Promise<EventEmitter> {
+        const emitter = new EventEmitter();
+
+        try {
+            logger.debug(`streamRequest ${this.name}`, acRequest.candidate);
+
+            const client = this.getClient(context);
+            const stream = await client.chat.completions.create(
+                { ...body, stream: true },
+                { signal: abortSignal }
+            ) as any;
+
+            let toolsData: ToolData[] = [];
+            let finishReason: TLLMFinishReason = TLLMFinishReason.Stop;
+            let usage: any = null;
+
+            setImmediate(() => {
+                (async () => {
+                    try {
+                        for await (const chunk of stream) {
+                            const delta = chunk.choices[0]?.delta;
+
+                            // OpenRouter streams usage in the final chunk
+                            if (chunk.usage) {
+                                usage = chunk.usage;
+                            }
+
+                            emitter.emit(TLLMEvent.Data, delta);
+
+                            if (delta?.content) {
+                                emitter.emit(TLLMEvent.Content, delta.content);
+                            }
+
+                            if (delta?.tool_calls) {
+                                delta.tool_calls.forEach((toolCall, index) => {
+                                    if (!toolsData[index]) {
+                                        toolsData[index] = {
+                                            index,
+                                            id: toolCall.id,
+                                            type: toolCall.type,
+                                            name: toolCall.function?.name,
+                                            arguments: toolCall.function?.arguments,
+                                            role: 'assistant',
+                                        };
+                                    } else {
+                                        toolsData[index].arguments += toolCall.function?.arguments || '';
+                                    }
+                                });
+                            }
+
+                            if (chunk.choices[0]?.finish_reason) {
+                                finishReason = LLMHelper.normalizeFinishReason(chunk.choices[0].finish_reason);
+                            }
+                        }
+
+                        if (toolsData.length > 0) {
+                            emitter.emit(TLLMEvent.ToolInfo, toolsData);
+                        }
+
+                        const reportedUsage: any[] = [];
+                        if (usage) {
+                            const reported = this.reportUsage(usage, {
+                                modelEntryName: context.modelEntryName,
+                                keySource: context.isUserKey ? APIKeySource.User : APIKeySource.Smyth,
+                                agentId: context.agentId,
+                                teamId: context.teamId,
+                            });
+                            reportedUsage.push(reported);
+                        }
+
+                        if (finishReason !== TLLMFinishReason.Stop) {
+                            emitter.emit(TLLMEvent.Interrupted, finishReason);
+                        }
+
+                        setTimeout(() => {
+                            emitter.emit(TLLMEvent.End, toolsData, reportedUsage, finishReason);
+                        }, 100);
+                    } catch (error: any) {
+                        const isAbort = error?.name === 'AbortError' || abortSignal?.aborted;
+                        if (isAbort) {
+                            logger.debug(`streamRequest ${this.name} aborted`, error, acRequest.candidate);
+                            const abortError = new DOMException('Request aborted', 'AbortError');
+                            emitter.emit(TLLMEvent.Abort, abortError);
+                            setImmediate(() => {
+                                emitter.emit(TLLMEvent.End, [], [], TLLMFinishReason.Abort);
+                            });
+                        } else {
+                            logger.error(`streamRequest ${this.name}`, error, acRequest.candidate);
+                            emitter.emit(TLLMEvent.Error, error);
+                            setImmediate(() => {
+                                emitter.emit(TLLMEvent.End, [], [], TLLMFinishReason.Error);
+                            });
+                        }
+                    }
+                })();
+            });
+
+            return emitter;
+        } catch (error: any) {
+            const isAbort = error?.name === 'AbortError' || abortSignal?.aborted;
+
+            if (isAbort) {
+                const abortError = new DOMException('Request aborted', 'AbortError');
+                logger.debug(`streamRequest ${this.name} aborted`, abortError, acRequest.candidate);
+                setImmediate(() => {
+                    emitter.emit(TLLMEvent.Abort, abortError);
+                    emitter.emit(TLLMEvent.End, [], [], TLLMFinishReason.Abort);
+                });
+                return emitter;
+            }
+
+            logger.error(`streamRequest ${this.name}`, error, acRequest.candidate);
+            setImmediate(() => {
+                emitter.emit(TLLMEvent.Error, error);
+                emitter.emit(TLLMEvent.End, [], [], TLLMFinishReason.Error);
+            });
+            return emitter;
+        }
+    }
+
+    // ── Request body adapter ──────────────────────────────────────────────────
+    // Maps SmythOS normalised params → OpenRouter request body.
+    // OpenRouter accepts the full OpenAI chat completions schema, so the mapping
+    // is straightforward with no provider-specific quirks.
+    protected async reqBodyAdapter(params: TLLMPreparedParams): Promise<OpenRouterRequestBody> {
+        const messages = params?.messages || [];
+
+        if (params?.responseFormat === 'json') {
+            if (messages?.[0]?.role === 'system') {
+                messages[0].content += JSON_RESPONSE_INSTRUCTION;
+            } else {
+                messages.unshift({ role: 'system', content: JSON_RESPONSE_INSTRUCTION });
+            }
+        }
+
+        const body: OpenRouterRequestBody = {
+            model: params.model as string,
+            messages,
+        };
+
+        if (params.maxTokens !== undefined) body.max_tokens = params.maxTokens;
+        if (params.temperature !== undefined) body.temperature = params.temperature;
+        if (params.topP !== undefined) body.top_p = params.topP;
+        if (params.stopSequences?.length) body.stop = params.stopSequences;
+        if (params.toolsConfig?.tools) body.tools = params.toolsConfig.tools;
+        if (params.toolsConfig?.tool_choice) body.tool_choice = params.toolsConfig.tool_choice as string;
+
+        return body;
+    }
+
+    // ── Usage reporting ───────────────────────────────────────────────────────
+    protected reportUsage(
+        usage: { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } },
+        metadata: { modelEntryName: string; keySource: APIKeySource; agentId: string; teamId: string }
+    ) {
+        const modelName = metadata.modelEntryName.replace(BUILT_IN_MODEL_PREFIX, '');
+
+        const usageData = {
+            sourceId: `llm:${modelName}`,
+            input_tokens: (usage?.prompt_tokens || 0) - (usage?.prompt_tokens_details?.cached_tokens || 0),
+            output_tokens: usage?.completion_tokens || 0,
+            input_tokens_cache_write: 0,
+            input_tokens_cache_read: usage?.prompt_tokens_details?.cached_tokens || 0,
+            keySource: metadata.keySource,
+            agentId: metadata.agentId,
+            teamId: metadata.teamId,
+        };
+
+        SystemEvents.emit('USAGE:LLM', usageData);
+        return usageData;
+    }
+
+    // ── Tool support ──────────────────────────────────────────────────────────
+    // OpenRouter supports OpenAI-style function calling on models that expose it
+    // (e.g. Mistral Large, Llama 3.3 70B, Qwen 2.5). The format is identical to
+    // the OpenAI/Groq tool calling schema.
+    public formatToolsConfig({ type = 'function', toolDefinitions, toolChoice = 'auto' }) {
+        if (type !== 'function') return {};
+
+        const tools = toolDefinitions.map(({ name, description, properties, requiredFields }) => ({
+            type: 'function',
+            function: {
+                name,
+                description,
+                parameters: {
+                    type: 'object',
+                    properties,
+                    required: requiredFields,
+                },
+            },
+        }));
+
+        return tools.length > 0 ? { tools, tool_choice: toolChoice } : {};
+    }
+
+    public transformToolMessageBlocks({
+        messageBlock,
+        toolsData,
+    }: {
+        messageBlock: TLLMMessageBlock;
+        toolsData: ToolData[];
+    }): TLLMToolResultMessageBlock[] {
+        const messageBlocks: TLLMToolResultMessageBlock[] = [];
+
+        if (messageBlock) {
+            const transformedMessageBlock = {
+                ...messageBlock,
+                content: typeof messageBlock.content === 'object' ? JSON.stringify(messageBlock.content) : messageBlock.content,
+            };
+            if (transformedMessageBlock.tool_calls) {
+                for (const toolCall of transformedMessageBlock.tool_calls) {
+                    toolCall.function.arguments =
+                        typeof toolCall.function.arguments === 'object'
+                            ? JSON.stringify(toolCall.function.arguments)
+                            : toolCall.function.arguments;
+                }
+            }
+            messageBlocks.push(transformedMessageBlock);
+        }
+
+        const transformedToolsData = toolsData.map((toolData) => ({
+            tool_call_id: toolData.id,
+            role: TLLMMessageRole.Tool,
+            name: toolData.name,
+            content: typeof toolData.result === 'string' ? toolData.result : JSON.stringify(toolData.result),
+        }));
+
+        return [...messageBlocks, ...transformedToolsData];
+    }
+
+    // ── Message normalisation ─────────────────────────────────────────────────
+    // Strips multimodal parts (images, audio) down to plain text since not all
+    // OpenRouter-hosted models support multimodal input. Models that do support
+    // vision can be handled via future feature flags in the model entry.
+    public getConsistentMessages(messages: TLLMMessageBlock[]): TLLMMessageBlock[] {
+        return LLMHelper.removeDuplicateUserMessages(messages).map((message) => {
+            const _message = { ...message };
+
+            if (message?.parts) {
+                _message.content = message.parts.map((block) => block?.text || '').join(' ');
+            } else if (Array.isArray(message?.content)) {
+                _message.content = message.content.map((block) => block?.text || '').join(' ');
+            }
+
+            return _message;
+        });
+    }
+}

--- a/packages/core/src/subsystems/LLMManager/LLM.service/index.ts
+++ b/packages/core/src/subsystems/LLMManager/LLM.service/index.ts
@@ -12,6 +12,7 @@ import { VertexAIConnector } from './connectors/VertexAI.class';
 import { PerplexityConnector } from './connectors/Perplexity.class';
 import { xAIConnector } from './connectors/xAI.class';
 import { OllamaConnector } from './connectors/Ollama.class';
+import { OpenRouterConnector } from './connectors/OpenRouter.class';
 
 export class LLMService extends ConnectorServiceProvider {
     public register() {
@@ -27,6 +28,7 @@ export class LLMService extends ConnectorServiceProvider {
         ConnectorService.register(TConnectorService.LLM, 'xAI', xAIConnector);
         ConnectorService.register(TConnectorService.LLM, 'Perplexity', PerplexityConnector);
         ConnectorService.register(TConnectorService.LLM, 'Ollama', OllamaConnector);
+        ConnectorService.register(TConnectorService.LLM, 'OpenRouter', OpenRouterConnector);
     }
 
     public init() {
@@ -43,5 +45,6 @@ export class LLMService extends ConnectorServiceProvider {
         ConnectorService.init(TConnectorService.LLM, 'xAI');
         ConnectorService.init(TConnectorService.LLM, 'Perplexity');
         ConnectorService.init(TConnectorService.LLM, 'Ollama');
+        ConnectorService.init(TConnectorService.LLM, 'OpenRouter');
     }
 }

--- a/packages/core/src/subsystems/LLMManager/models.ts
+++ b/packages/core/src/subsystems/LLMManager/models.ts
@@ -2530,6 +2530,104 @@ export const models = {
         credentials: 'vault',
     },
 
+    // #region OpenRouter ==========================
+    // OpenRouter provides a unified gateway to 100+ models via one API key.
+    // All entries use tokens: 0 / completionTokens: 0 (disabled for SmythOS-managed keys)
+    // and are enabled only when the user supplies their own OpenRouter API key via keyOptions.
+
+    'openrouter/mistral-large': {
+        provider: 'OpenRouter',
+        label: 'Mistral Large (OpenRouter)',
+        modelId: 'mistralai/mistral-large',
+        features: ['text', 'tools'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 128_000, completionTokens: 8_192, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/meta-llama/llama-3.3-70b': {
+        provider: 'OpenRouter',
+        label: 'Llama 3.3 70B Instruct (OpenRouter)',
+        modelId: 'meta-llama/llama-3.3-70b-instruct',
+        features: ['text', 'tools'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 128_000, completionTokens: 4_096, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/qwen/qwen-2.5-72b': {
+        provider: 'OpenRouter',
+        label: 'Qwen 2.5 72B Instruct (OpenRouter)',
+        modelId: 'qwen/qwen-2.5-72b-instruct',
+        features: ['text', 'tools'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 131_072, completionTokens: 8_192, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/google/gemma-3-27b': {
+        provider: 'OpenRouter',
+        label: 'Gemma 3 27B (OpenRouter)',
+        modelId: 'google/gemma-3-27b-it',
+        features: ['text'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 131_072, completionTokens: 8_192, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/deepseek/deepseek-r1': {
+        provider: 'OpenRouter',
+        label: 'DeepSeek R1 (OpenRouter)',
+        modelId: 'deepseek/deepseek-r1',
+        features: ['text', 'reasoning'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 163_840, completionTokens: 32_768, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/microsoft/phi-4': {
+        provider: 'OpenRouter',
+        label: 'Phi-4 (OpenRouter)',
+        modelId: 'microsoft/phi-4',
+        features: ['text', 'tools'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 16_384, completionTokens: 4_096, enabled: true },
+        credentials: 'vault',
+    },
+
+    'openrouter/cohere/command-r-plus': {
+        provider: 'OpenRouter',
+        label: 'Command R+ (OpenRouter)',
+        modelId: 'cohere/command-r-plus',
+        features: ['text', 'tools'],
+        tags: ['Personal', 'OpenRouter'],
+        tokens: 0,
+        completionTokens: 0,
+        enabled: false,
+        keyOptions: { tokens: 128_000, completionTokens: 4_096, enabled: true },
+        credentials: 'vault',
+    },
+
+    // #endregion OpenRouter ==========================
+
     // #endregion [User Models] ==============================================================
 };
 

--- a/packages/core/tests/integration/003-LLM/openrouter/openrouter.test.ts
+++ b/packages/core/tests/integration/003-LLM/openrouter/openrouter.test.ts
@@ -1,0 +1,183 @@
+/**
+ * OpenRouter Integration Tests
+ *
+ * These tests verify that the OpenRouterConnector works end-to-end with the
+ * real OpenRouter API. They cover:
+ *   - Basic prompt (non-streaming)
+ *   - Streaming prompt via EventEmitter
+ *   - Tool calling (function calling)
+ *   - JSON response format
+ *
+ * Requirements:
+ *   - A valid OPENROUTER_API_KEY must be available in the vault / environment.
+ *   - Integration test consent must be given (see test-data-manager).
+ *
+ * Test model: openrouter/mistral-large
+ * Mistral Large supports text generation and tool calling, making it a good
+ * representative model for validating the full connector surface area.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { LLMInference } from '@sre/LLMManager/LLM.inference';
+import { AccessCandidate } from '@sre/Security/AccessControl/AccessCandidate.class';
+import { TLLMEvent, TLLMMessageRole } from '@sre/types/LLM.types';
+import { setupSRE } from '../../../utils/sre';
+import { checkIntegrationTestConsent } from '../../../utils/test-data-manager';
+
+checkIntegrationTestConsent();
+setupSRE();
+
+const TEST_MODEL = 'openrouter/mistral-large';
+const agentId = 'cm0zjhkzx0dfvhxf81u76taiz';
+const TIMEOUT = 30_000;
+
+// A unique string injected into prompts so we can assert the model actually
+// followed the instruction and the response is not a cached/stubbed value.
+const LLM_OUTPUT_VALIDATOR = 'Yohohohooooo!';
+const WORD_INCLUSION_PROMPT = `\nAll your responses must include "${LLM_OUTPUT_VALIDATOR}". If the response is JSON, include an additional key "${LLM_OUTPUT_VALIDATOR}" with value "${LLM_OUTPUT_VALIDATOR}".\n\n`;
+
+describe(`OpenRouter Connector — ${TEST_MODEL}`, async () => {
+    let llmInference: LLMInference;
+    let baseParams: any;
+
+    beforeEach(async () => {
+        llmInference = await LLMInference.getInstance(TEST_MODEL, AccessCandidate.team('default'));
+
+        baseParams = {
+            model: TEST_MODEL,
+            maxTokens: 256,
+            temperature: 0.5,
+            agentId,
+        };
+    });
+
+    // ── Basic prompt ──────────────────────────────────────────────────────────
+    it(
+        'returns a valid response for a simple prompt',
+        async () => {
+            const result = await llmInference.prompt({
+                query: WORD_INCLUSION_PROMPT + 'What is the capital of France?',
+                params: baseParams,
+            });
+
+            expect(result).toBeTruthy();
+            expect(JSON.stringify(result)).toContain(LLM_OUTPUT_VALIDATOR);
+        },
+        TIMEOUT
+    );
+
+    it(
+        'handles a system message correctly',
+        async () => {
+            const messages = [
+                { role: TLLMMessageRole.System, content: 'You are a helpful assistant. ' + WORD_INCLUSION_PROMPT },
+                { role: TLLMMessageRole.User, content: 'What can you do?' },
+            ];
+
+            const result = await llmInference.prompt({
+                contextWindow: messages,
+                params: baseParams,
+            });
+
+            expect(result).toBeTruthy();
+            expect(JSON.stringify(result)).toContain(LLM_OUTPUT_VALIDATOR);
+        },
+        TIMEOUT
+    );
+
+    // ── JSON response format ──────────────────────────────────────────────────
+    it(
+        'returns a parseable JSON object when responseFormat is json',
+        async () => {
+            const result = await llmInference.prompt({
+                query: WORD_INCLUSION_PROMPT + 'Name three programming languages.',
+                params: { ...baseParams, responseFormat: 'json' },
+            });
+
+            expect(result).toBeTruthy();
+            // LLMInference.prompt already parses JSON responses — result should be an object
+            expect(typeof result).toBe('object');
+            expect(JSON.stringify(result)).toContain(LLM_OUTPUT_VALIDATOR);
+        },
+        TIMEOUT
+    );
+
+    // ── Streaming ─────────────────────────────────────────────────────────────
+    it(
+        'streams content chunks via EventEmitter',
+        async () => {
+            let streamedContent = '';
+            let endFired = false;
+
+            // promptStream returns the EventEmitter — attach listeners on it.
+            // The setImmediate inside OpenRouterConnector.streamRequest defers all
+            // event emission to the next tick, so attaching listeners immediately
+            // after the await is safe and race-condition-free.
+            const emitter = await llmInference.promptStream({
+                query: WORD_INCLUSION_PROMPT + 'Tell me a one-sentence fun fact about space.',
+                params: baseParams,
+            });
+
+            const streamComplete = new Promise<void>((resolve) => {
+                emitter.on(TLLMEvent.Content, (chunk: string) => {
+                    streamedContent += chunk;
+                });
+                emitter.on(TLLMEvent.End, () => {
+                    endFired = true;
+                    resolve();
+                });
+            });
+
+            await streamComplete;
+
+            expect(streamedContent).toBeTruthy();
+            expect(streamedContent).toContain(LLM_OUTPUT_VALIDATOR);
+            expect(endFired).toBe(true);
+        },
+        TIMEOUT
+    );
+
+    // ── Tool calling ──────────────────────────────────────────────────────────
+    it(
+        'invokes a tool and returns tool call data',
+        async () => {
+            const toolDefinitions = [
+                {
+                    name: 'get_weather',
+                    description: 'Get the current weather for a given city',
+                    properties: {
+                        location: { type: 'string', description: 'City name' },
+                    },
+                    requiredFields: ['location'],
+                },
+            ];
+
+            const toolsConfig: any = llmInference.connector.formatToolsConfig({
+                type: 'function',
+                toolDefinitions,
+                toolChoice: 'auto',
+            });
+
+            let toolsData: any[] = [];
+
+            const emitter = await llmInference.promptStream({
+                query: "What's the weather like in Paris right now?",
+                params: { ...baseParams, toolsConfig },
+            });
+
+            const streamComplete = new Promise<void>((resolve) => {
+                emitter.on(TLLMEvent.ToolInfo, (data: any[]) => {
+                    toolsData = toolsData.concat(data);
+                });
+                emitter.on(TLLMEvent.End, () => resolve());
+            });
+
+            await streamComplete;
+
+            expect(toolsData.length).toBeGreaterThan(0);
+            expect(toolsData[0].name).toBe('get_weather');
+            expect(JSON.parse(toolsData[0].arguments)).toHaveProperty('location');
+        },
+        TIMEOUT
+    );
+});


### PR DESCRIPTION
## Summary

- Adds `OpenRouterConnector` — a dedicated LLM connector giving SmythOS agents
  access to 100+ models (Mistral, Llama, Qwen, Gemma, DeepSeek, Phi, Command R+)
  through a single OpenRouter API key
- Registers the connector in `LLM.service/index.ts` (+3 lines, zero changes to core engine)
- Adds 7 initial model entries to `models.ts` under a new `#region OpenRouter` section
- Adds 5 integration tests (prompt, system message, JSON mode, streaming, tool calling)
  — all passing against the live API

## Why OpenRouter and not just Groq

Groq = **speed** (LPU hardware, ~15 curated models)
OpenRouter = **choice** (100+ models, automatic provider fallback, day-of-release availability)

They are complementary, not redundant. Users wanting Mistral, Llama 3.3, Qwen 2.5,
Gemma 3, or DeepSeek R1 currently have no path in SmythOS. This PR fixes that
with one connector.

## Why a dedicated connector (not reusing OpenAIConnector)

OpenRouter requires identifying HTTP headers (`HTTP-Referer`, `X-Title`) that the
existing OpenAI connector has no mechanism to send. A dedicated connector also
provides a clean foundation for future OpenRouter-specific features such as
provider routing config and per-request cost tracking via the `usage.cost` field
returned in every OpenRouter response.

## Files changed

| File | Change |
|---|---|
| `connectors/OpenRouter.class.ts` | New — full connector (395 lines) |
| `LLM.service/index.ts` | +3 lines: import, register, init |
| `models.ts` | +7 model entries in new `#region OpenRouter` |
| `tests/integration/003-LLM/openrouter/openrouter.test.ts` | New — 5 integration tests |

## Test plan

- [x] Simple prompt returns valid response
- [x] System message handled correctly
- [x] JSON response format (`responseFormat: json`) works
- [x] Streaming via EventEmitter works end-to-end
- [x] Tool calling (function calling) works — tested with Mistral Large
- [x] Full TypeScript build passes — no new errors, no regressions
- [x] All 157 existing unit tests still pass


