### PR TITLE
fix(otel): enhance LLM components to include processId and teamId in parameters

### DIFF
--- a/packages/core/src/Components/Classifier.class.ts
+++ b/packages/core/src/Components/Classifier.class.ts
@@ -133,6 +133,8 @@ ${JSON.stringify(categories, null, 2)}`;
                             params: {
                                 ...config.data,
                                 agentId: agent.id,
+                                processId: agent.agentRuntime?.processID,
+                                teamId: agent.teamId,
                                 responseFormat: 'json',
                             },
                             onFallback: (fallbackInfo) => {

--- a/packages/core/src/Components/GenAILLM.class.ts
+++ b/packages/core/src/Components/GenAILLM.class.ts
@@ -517,6 +517,8 @@ export class GenAILLM extends Component {
                         params: {
                             ...resolvedConfigData,
                             agentId: agent.id,
+                            processId: agent.agentRuntime?.processID,
+                            teamId: agent.teamId,
                         },
                         onFallback: (fallbackInfo) => {
                             logger.debug(`\n ↩️ Using fallback model: ${fallbackInfo.model}`);

--- a/packages/core/src/Components/LLMAssistant.class.ts
+++ b/packages/core/src/Components/LLMAssistant.class.ts
@@ -163,7 +163,7 @@ export class LLMAssistant extends Component {
                     const eventEmitter: any = await llmInference
                         .promptStream({
                             contextWindow: messages,
-                            params: { ...config, model, agentId: agent.id },
+                            params: { ...config, model, agentId: agent.id, processId: agent.agentRuntime?.processID, teamId: agent.teamId },
                             onFallback: (fallbackInfo) => {
                                 logger.debug(`\n ↩️ Using fallback model: ${fallbackInfo.model}`);
                             },

--- a/packages/core/src/Components/MultimodalLLM.class.ts
+++ b/packages/core/src/Components/MultimodalLLM.class.ts
@@ -96,7 +96,7 @@ export class MultimodalLLM extends Component {
                 });
                 response = await contentPromise;
             } else {
-                response = await llmInference.prompt({ query: prompt, files, params: { ...config, agentId: agent.id } });
+                response = await llmInference.prompt({ query: prompt, files, params: { ...config, agentId: agent.id, processId: agent.agentRuntime?.processID, teamId: agent.teamId } });
             }
 
             // in case we have the response but it's empty string, undefined or null

--- a/packages/core/src/Components/PromptGenerator.class.ts
+++ b/packages/core/src/Components/PromptGenerator.class.ts
@@ -65,7 +65,7 @@ export class PromptGenerator extends Component {
                     const eventEmitter: any = await llmInference
                         .promptStream({
                             query: prompt,
-                            params: { ...config, model, agentId: agent.id },
+                            params: { ...config, model, agentId: agent.id, processId: agent.agentRuntime?.processID, teamId: agent.teamId },
                         })
                         .catch((error) => {
                             console.error('Error on promptStream: ', error);
@@ -92,7 +92,7 @@ export class PromptGenerator extends Component {
                 response = await contentPromise;
             } else {
                 response = await llmInference
-                    .prompt({ query: prompt, params: { ...config, agentId: agent.id } })
+                    .prompt({ query: prompt, params: { ...config, agentId: agent.id, processId: agent.agentRuntime?.processID, teamId: agent.teamId } })
                     .catch((error) => ({ error: error }));
             }
 

--- a/packages/core/src/Components/VisionLLM.class.ts
+++ b/packages/core/src/Components/VisionLLM.class.ts
@@ -75,7 +75,7 @@ export class VisionLLM extends Component {
                 });
                 response = await contentPromise;
             } else {
-                response = await llmInference.prompt({ query: prompt, files, params: { ...config, agentId: agent.id } });
+                response = await llmInference.prompt({ query: prompt, files, params: { ...config, agentId: agent.id, processId: agent.agentRuntime?.processID, teamId: agent.teamId } });
             }
 
             // in case we have the response but it's empty string, undefined or null

--- a/packages/core/src/helpers/Conversation.helper.ts
+++ b/packages/core/src/helpers/Conversation.helper.ts
@@ -353,6 +353,8 @@ export class Conversation extends EventEmitter {
                     maxTokens,
                     cache: this._settings?.experimentalCache,
                     agentId: this._agentId,
+                    processId: this.storeId || this.id,
+                    teamId: this.agentData?.teamId,
                     abortSignal,
                 },
             })

--- a/packages/core/src/subsystems/LLMManager/LLM.inference.ts
+++ b/packages/core/src/subsystems/LLMManager/LLM.inference.ts
@@ -4,6 +4,7 @@ import { ChatMessage } from 'gpt-tokenizer/esm/GptEncoding';
 
 import { isAgent } from '@sre/AgentManager/Agent.helper';
 import { ConnectorService } from '@sre/Core/ConnectorsService';
+import { hookAsync } from '@sre/Core/HookService';
 import { BinaryInput } from '@sre/helpers/BinaryInput.helper';
 import { Logger } from '@sre/helpers/Log.helper';
 import { AccessCandidate } from '@sre/Security/AccessControl/AccessCandidate.class';
@@ -73,6 +74,7 @@ export class LLMInference {
         return this._llmConnector;
     }
 
+    @hookAsync('LLMInference.prompt')
     public async prompt({ query, contextWindow, files, params, onFallback = () => {} }: TPromptParams, isInFallback: boolean = false) {
         let messages = contextWindow || [];
 
@@ -133,6 +135,7 @@ export class LLMInference {
         }
     }
 
+    @hookAsync('LLMInference.promptStream')
     public async promptStream({ query, contextWindow, files, params, onFallback = () => {} }: TPromptParams, isInFallback: boolean = false) {
         let messages = contextWindow || [];
 

--- a/packages/core/src/subsystems/ObservabilityManager/Telemetry.service/connectors/OTel/OTel.class.ts
+++ b/packages/core/src/subsystems/ObservabilityManager/Telemetry.service/connectors/OTel/OTel.class.ts
@@ -333,80 +333,6 @@ export class OTel extends TelemetryConnector {
             };
         };
 
-        const createDataHandler = function (hookContext) {
-            return function (data: any, reqInfo: any) {
-                if (!hookContext.convSpan) return;
-                if (hookContext.curLLMGenSpan) return;
-                const accessCandidate = AccessCandidate.agent(hookContext?.agentId);
-                if (OTEL_DEBUG_LOGS) outputLogger.debug('createDataHandler started', reqInfo?.requestId, accessCandidate);
-
-                const modelId = reqInfo.model;
-                const contextWindow = reqInfo.contextWindow;
-
-                // End TTFB span when first data arrives
-                if (hookContext?.latencySpans?.[reqInfo.requestId]) {
-                    const ttfbSpan = hookContext.latencySpans[reqInfo.requestId];
-
-                    // Calculate actual TTFB duration and add as attribute
-                    ttfbSpan.addEvent('llm.first.byte.received', {
-                        'request.id': reqInfo.requestId,
-                        'data.size': JSON.stringify(data || {}).length,
-                        'llm.model': modelId || '',
-                    });
-
-                    ttfbSpan.setStatus({ code: SpanStatusCode.OK });
-                    ttfbSpan.end();
-
-                    delete hookContext.latencySpans[reqInfo.requestId];
-                }
-
-                const llmGenSpan = tracer.startSpan(
-                    'Conv.GenAI',
-                    {
-                        attributes: {
-                            'agent.id': hookContext.agentId,
-                            'conv.id': hookContext.processId,
-                            'team.id': hookContext.teamId,
-                            'llm.model': modelId || '',
-                        },
-                    },
-                    trace.setSpan(context.active(), hookContext.convSpan),
-                );
-                llmGenSpan.addEvent('llm.gen.started', {
-                    'request.id': reqInfo.requestId,
-                    timestamp: Date.now(),
-                    'llm.model': modelId || '',
-                    'context.preview': oTelInstance.redactString(oTelInstance.prepareContext(contextWindow).substring(0, 200)),
-                });
-
-                const llmGenSpanCtx = llmGenSpan.spanContext();
-                const llmGenSpanContext = trace.setSpan(context.active(), llmGenSpan);
-                context.with(llmGenSpanContext, () => {
-                    logger.emit({
-                        severityNumber: SeverityNumber.INFO,
-                        severityText: 'INFO',
-                        body: `LLM generation started: ${hookContext.processId}`,
-                        attributes: {
-                            // Explicit trace correlation (some backends need these)
-                            trace_id: llmGenSpanCtx.traceId,
-                            span_id: llmGenSpanCtx.spanId,
-                            trace_flags: llmGenSpanCtx.traceFlags,
-
-                            'agent.id': hookContext.agentId,
-                            'conv.id': hookContext.processId,
-                            'team.id': hookContext.teamId,
-                            'llm.model': modelId || '',
-                            'request.id': reqInfo.requestId,
-                            'context.preview': oTelInstance.redactString(oTelInstance.prepareContext(contextWindow)),
-                        },
-                    });
-                });
-
-                hookContext.curLLMGenSpan = llmGenSpan;
-                if (OTEL_DEBUG_LOGS) outputLogger.debug('createDataHandler completed', reqInfo?.requestId, accessCandidate);
-            };
-        };
-
         const createErrorHandler = function (hookContext: any) {
             return function (error: Error, metadata?: { requestId?: string }) {
                 if (!hookContext.convSpan) return;
@@ -459,38 +385,6 @@ export class OTel extends TelemetryConnector {
             };
         };
 
-        const createRequestedHandler = function (hookContext) {
-            return function (reqInfo: any) {
-                if (!hookContext.convSpan) return;
-                const accessCandidate = AccessCandidate.agent(hookContext?.agentId);
-                if (OTEL_DEBUG_LOGS) outputLogger.debug('createRequestedHandler started', reqInfo?.requestId, accessCandidate);
-                if (!hookContext.latencySpans) hookContext.latencySpans = {};
-                const contextWindow = reqInfo.contextWindow;
-
-                const modelId = reqInfo.model;
-                const llmGenLatencySpan = tracer.startSpan(
-                    'Conv.GenAI.TTFB',
-                    {
-                        attributes: {
-                            'agent.id': hookContext.agentId,
-                            'conv.id': hookContext.processId,
-                            'team.id': hookContext.teamId,
-                            'request.id': reqInfo.requestId,
-                            'llm.model': modelId || '',
-                            'metric.type': 'ttfb',
-                        },
-                    },
-                    trace.setSpan(context.active(), hookContext.convSpan),
-                );
-                llmGenLatencySpan.addEvent('llm.requested', {
-                    'request.id': reqInfo.requestId,
-                    timestamp: Date.now(),
-                    'context.preview': oTelInstance.redactString(oTelInstance.prepareContext(contextWindow).substring(0, 200)),
-                });
-                hookContext.latencySpans[reqInfo.requestId] = llmGenLatencySpan;
-                if (OTEL_DEBUG_LOGS) outputLogger.debug('createRequestedHandler completed', reqInfo?.requestId, accessCandidate);
-            };
-        };
         HookService.register(
             'Conversation.streamPrompt',
             async function (additionalContext, args) {
@@ -560,12 +454,6 @@ export class OTel extends TelemetryConnector {
                 if (OTEL_DEBUG_LOGS) {
                     outputLogger.debug('Injected trace headers into conversation', { processId, headers });
                 }
-
-                hookContext.dataHandler = createDataHandler(hookContext);
-                conversation.on(TLLMEvent.Data, hookContext.dataHandler);
-
-                hookContext.requestedHandler = createRequestedHandler(hookContext);
-                conversation.on(TLLMEvent.Requested, hookContext.requestedHandler);
 
                 hookContext.toolInfoHandler = createToolInfoHandler(hookContext);
                 conversation.on(TLLMEvent.ToolInfo, hookContext.toolInfoHandler);
@@ -647,24 +535,7 @@ export class OTel extends TelemetryConnector {
                 const accessCandidate = AccessCandidate.agent(agentId);
                 if (OTEL_DEBUG_LOGS) outputLogger.debug('Conversation.streamPrompt completed', { processId }, accessCandidate);
 
-                // Handle curLLMGenSpan with error awareness
-                if (hookContext.curLLMGenSpan) {
-                    if (error) {
-                        hookContext.curLLMGenSpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-                    }
-                    hookContext.curLLMGenSpan.addEvent('llm.gen.content', {
-                        'content.size': JSON.stringify(result || {}).length,
-                        'content.preview': oTelInstance.redactString(
-                            typeof result === 'string' ? result.substring(0, 200) : JSON.stringify(result || {}).substring(0, 200),
-                        ),
-                    });
-                    hookContext.curLLMGenSpan.end();
-
-                    if (hookContext.toolInfoHandler) conversation.off(TLLMEvent.ToolInfo, hookContext.toolInfoHandler);
-                    if (hookContext.dataHandler) conversation.off(TLLMEvent.Data, hookContext.dataHandler);
-                    if (hookContext.requestedHandler) conversation.off(TLLMEvent.Requested, hookContext.requestedHandler);
-                }
-
+                if (hookContext.toolInfoHandler) conversation.off(TLLMEvent.ToolInfo, hookContext.toolInfoHandler);
                 if (hookContext.errorHandler) conversation.off(TLLMEvent.Error, hookContext.errorHandler);
 
                 const { rootSpan: convSpan } = ctx;
@@ -1007,6 +878,223 @@ export class OTel extends TelemetryConnector {
                     agentSpan.end();
                     OTelContextRegistry.endProcess(agentId, agentProcessId);
                 }
+            },
+            THook.NonBlocking,
+        );
+
+        // LLMInference.promptStream hook — creates Conv.GenAI.TTFB and Conv.GenAI spans
+        // for ALL LLM streaming calls regardless of whether they originate from
+        // Conversation.streamPrompt or from components like GenAILLM.
+        HookService.register(
+            'LLMInference.promptStream',
+            async function (promptParams) {
+                const params = promptParams?.params;
+                if (!params) return;
+
+                const llmInference = this.instance;
+                const agentId = params.agentId;
+                const teamId = params.teamId || llmInference?.teamId;
+                const processId = params.processId;
+                const modelId = llmInference?.modelId || '';
+
+                if (!agentId || !teamId) return;
+
+                const hookContext: any = this.context;
+                hookContext.agentId = agentId;
+                hookContext.teamId = teamId;
+                hookContext.processId = processId;
+                hookContext.modelId = modelId;
+
+                const parentCtx = processId ? OTelContextRegistry.get(agentId, processId) : undefined;
+                const parentSpan = parentCtx?.rootSpan;
+
+                const ttfbSpan = tracer.startSpan(
+                    'Conv.GenAI.TTFB',
+                    {
+                        attributes: {
+                            'agent.id': agentId,
+                            'conv.id': processId || '',
+                            'team.id': teamId,
+                            'llm.model': modelId,
+                            'metric.type': 'ttfb',
+                        },
+                    },
+                    parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined,
+                );
+
+                hookContext.ttfbSpan = ttfbSpan;
+                hookContext.ttfbEnded = false;
+                hookContext.genSpanEnded = false;
+            },
+            THook.NonBlocking,
+        );
+
+        HookService.registerAfter(
+            'LLMInference.promptStream',
+            async function ({ result: emitter, error }) {
+                const hookContext: any = this.context;
+                const ttfbSpan = hookContext?.ttfbSpan;
+                if (!ttfbSpan) return;
+
+                if (error || !emitter || typeof emitter.on !== 'function') {
+                    if (error) {
+                        ttfbSpan.recordException(error);
+                        ttfbSpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message || 'LLM request failed' });
+                    }
+                    ttfbSpan.end();
+                    hookContext.ttfbEnded = true;
+                    return;
+                }
+
+                const agentId = hookContext.agentId;
+                const teamId = hookContext.teamId;
+                const processId = hookContext.processId;
+                const modelId = hookContext.modelId;
+
+                const parentCtx = processId ? OTelContextRegistry.get(agentId, processId) : undefined;
+                const parentSpan = parentCtx?.rootSpan;
+
+                let firstByte = true;
+
+                emitter.on(TLLMEvent.Content, () => {
+                    if (!firstByte) return;
+                    firstByte = false;
+
+                    if (!hookContext.ttfbEnded) {
+                        ttfbSpan.setStatus({ code: SpanStatusCode.OK });
+                        ttfbSpan.end();
+                        hookContext.ttfbEnded = true;
+                    }
+
+                    const genSpan = tracer.startSpan(
+                        'Conv.GenAI',
+                        {
+                            attributes: {
+                                'agent.id': agentId,
+                                'conv.id': processId || '',
+                                'team.id': teamId,
+                                'llm.model': modelId,
+                            },
+                        },
+                        parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined,
+                    );
+                    hookContext.genSpan = genSpan;
+                });
+
+                emitter.on(TLLMEvent.End, () => {
+                    if (!hookContext.ttfbEnded) {
+                        ttfbSpan.setStatus({ code: SpanStatusCode.OK });
+                        ttfbSpan.end();
+                        hookContext.ttfbEnded = true;
+                    }
+                    if (hookContext.genSpan && !hookContext.genSpanEnded) {
+                        hookContext.genSpan.setStatus({ code: SpanStatusCode.OK });
+                        hookContext.genSpan.end();
+                        hookContext.genSpanEnded = true;
+                    }
+                });
+
+                emitter.on(TLLMEvent.Error, (err: Error) => {
+                    if (!hookContext.ttfbEnded) {
+                        ttfbSpan.recordException(err);
+                        ttfbSpan.setStatus({ code: SpanStatusCode.ERROR, message: err?.message || 'LLM error' });
+                        ttfbSpan.end();
+                        hookContext.ttfbEnded = true;
+                    }
+                    if (hookContext.genSpan && !hookContext.genSpanEnded) {
+                        hookContext.genSpan.recordException(err);
+                        hookContext.genSpan.setStatus({ code: SpanStatusCode.ERROR, message: err?.message || 'LLM error' });
+                        hookContext.genSpan.end();
+                        hookContext.genSpanEnded = true;
+                    }
+                });
+            },
+            THook.NonBlocking,
+        );
+
+        // LLMInference.prompt hook — creates Conv.GenAI.TTFB and Conv.GenAI spans
+        // for non-streaming LLM calls (e.g. VisionLLM, MultimodalLLM).
+        HookService.register(
+            'LLMInference.prompt',
+            async function (promptParams) {
+                const params = promptParams?.params;
+                if (!params) return;
+
+                const llmInference = this.instance;
+                const agentId = params.agentId;
+                const teamId = params.teamId || llmInference?.teamId;
+                const processId = params.processId;
+                const modelId = llmInference?.modelId || '';
+
+                if (!agentId || !teamId) return;
+
+                const hookContext: any = this.context;
+                hookContext.agentId = agentId;
+                hookContext.teamId = teamId;
+                hookContext.processId = processId;
+                hookContext.modelId = modelId;
+
+                const parentCtx = processId ? OTelContextRegistry.get(agentId, processId) : undefined;
+                const parentSpan = parentCtx?.rootSpan;
+
+                const ttfbSpan = tracer.startSpan(
+                    'Conv.GenAI.TTFB',
+                    {
+                        attributes: {
+                            'agent.id': agentId,
+                            'conv.id': processId || '',
+                            'team.id': teamId,
+                            'llm.model': modelId,
+                            'metric.type': 'ttfb',
+                        },
+                    },
+                    parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined,
+                );
+
+                hookContext.ttfbSpan = ttfbSpan;
+            },
+            THook.NonBlocking,
+        );
+
+        HookService.registerAfter(
+            'LLMInference.prompt',
+            async function ({ result, error }) {
+                const hookContext: any = this.context;
+                const ttfbSpan = hookContext?.ttfbSpan;
+                if (!ttfbSpan) return;
+
+                const agentId = hookContext.agentId;
+                const teamId = hookContext.teamId;
+                const processId = hookContext.processId;
+                const modelId = hookContext.modelId;
+
+                const parentCtx = processId ? OTelContextRegistry.get(agentId, processId) : undefined;
+                const parentSpan = parentCtx?.rootSpan;
+
+                if (error) {
+                    ttfbSpan.recordException(error);
+                    ttfbSpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message || 'LLM request failed' });
+                    ttfbSpan.end();
+                    return;
+                }
+
+                ttfbSpan.setStatus({ code: SpanStatusCode.OK });
+                ttfbSpan.end();
+
+                const genSpan = tracer.startSpan(
+                    'Conv.GenAI',
+                    {
+                        attributes: {
+                            'agent.id': agentId,
+                            'conv.id': processId || '',
+                            'team.id': teamId,
+                            'llm.model': modelId,
+                        },
+                    },
+                    parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined,
+                );
+                genSpan.setStatus({ code: SpanStatusCode.OK });
+                genSpan.end();
             },
             THook.NonBlocking,
         );

--- a/packages/core/src/types/LLM.types.ts
+++ b/packages/core/src/types/LLM.types.ts
@@ -179,6 +179,7 @@ type TLLMRuntimeContext = {
     cache?: boolean;
     agentId?: string;
     teamId?: string;
+    processId?: string;
 };
 
 type TLLMImageGenConfig = {


### PR DESCRIPTION
## 📝 Description

Added processId and teamId to the parameters of various LLM components (Classifier, GenAILLM, LLMAssistant, MultimodalLLM, PromptGenerator, VisionLLM) to improve context tracking. Updated the Conversation helper to include these fields as well. Additionally, introduced hooks for prompt and promptStream methods in LLMInference for better extensibility.

## 🔗 Related Issues

<!-- Link to related issues using "Fixes #123" or "Relates to #123" -->

-   Fixes # [https://app.clickup.com/t/86ew67ge0](https://app.clickup.com/t/86ew67ge0)
-   Relates to #

## 🔧 Type of Change

<!-- Mark the relevant option with an "x" -->

-   [x] 🐛 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Code refactoring (no functional changes)
-   [ ] 🧪 Test improvements
-   [ ] 🔨 Build/CI changes

## ✅ Checklist

<!-- Ensure all items are completed before submitting -->

-   [x] Self-review performed
-   [ ] Tests added/updated
-   [ ] Documentation updated (if needed)
